### PR TITLE
chore: extract Jest config and update tsconfig to resolve path issues

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,21 @@
+import { Config } from 'jest';
+import { pathsToModuleNameMapper } from 'ts-jest';
+import { compilerOptions } from './tsconfig.json';
+
+const config: Config = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -58,22 +58,5 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.1.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,13 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "resolveJsonModule": true,
+    "paths": {
+      "@application/*": ["./src/application/*"],
+      "@infra/*": ["./src/infra/*"],
+      "@helpers/*": ["./src/helpers/*"],
+      "@test/*": ["./test/*"]
+    }
   }
 }


### PR DESCRIPTION
**Description**
I made updates to the tsconfig.json file to improve module resolution and path aliasing. These changes help with cleaner imports and better organization of the project structure.

**Changes made:**
Enabled JSON module resolution by adding "resolveJsonModule": true.
Added custom path aliases to improve import statements:

```
"paths": {
  "@application/*": ["./src/application/*"],
  "@infra/*": ["./src/infra/*"],
  "@helpers/*": ["./src/helpers/*"],
  "@test/*": ["./test/*"]
}
```

**Reason for the change:**
These modifications make the project structure more scalable and improve code readability by simplifying import paths.